### PR TITLE
Development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
 
 ARG CMAKE_VER=3.17.5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN ( \
   ) > /etc/ssh/sshd_config_development \
   && mkdir /run/sshd
 
+ENV DEBIAN_FRONTEND=keyboard-interactive
 RUN useradd -m remote && yes password | passwd remote
 
 CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config_development"]


### PR DESCRIPTION
* Use ubuntu:20.04 as base image (previous was 18.04)

* Set frontend environment to noninteractive to prevent
hanging during apt update / install configuration stage:
>> Setting up tzdata (2021a-0ubuntu0.20.04)

(it prompts for user input to select the timezone)

* Switch back to interactive frontend at the end to
allow setting ssh password and access

Tested locally and in CI, works as expected.